### PR TITLE
Applied QTBUG-22829 work around (boost/qt4 compatibility)

### DIFF
--- a/src/Logger2.h
+++ b/src/Logger2.h
@@ -28,6 +28,7 @@
 
 #include <opencv2/opencv.hpp>
 
+#ifndef Q_MOC_RUN
 #include <boost/format.hpp>
 #include <boost/thread.hpp>
 #include <boost/lexical_cast.hpp>
@@ -38,6 +39,7 @@
 #include "OpenNI2/OpenNI2Interface.h"
 #include "MemoryBuffer.h"
 #include "TcpHandler.h"
+#endif
 
 class Logger2
 {

--- a/src/main.h
+++ b/src/main.h
@@ -38,8 +38,11 @@
 #include <iomanip>
 #include <iostream>
 #include <math.h>
+
+#ifndef Q_MOC_RUN
 #include <boost/date_time/gregorian/gregorian.hpp>
 #include <boost/filesystem.hpp>
+#endif
 
 #include "Logger2.h"
 #include "Communicator.h"


### PR DESCRIPTION
There is an incompatibility between Qt4 and newer boost releases, as described here:
https://bugreports.qt.io/browse/QTBUG-22829

I applied the discussed work around in order to build the logger on my system.
